### PR TITLE
Add MIT License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Artisan Build
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,17 @@ subprocess.run(["./bg-remover", "-i", "input.jpg", "-o", "output.png"], check=Tr
 - Memory usage: ~3-4x input file size in RAM
 - Best results with single subjects on contrasting backgrounds
 
+## Dependencies
+
+This software uses the following open source packages:
+
+- [OpenCV](https://opencv.org/) - Apache 2.0 License
+  - Used for image processing and background removal algorithms
+  - Must be installed separately (see Requirements section)
+  - License: https://opencv.org/license/
+
 ## License
 
-See LICENSE file for details.
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+
+OpenCV is licensed under the Apache 2.0 License, which is compatible with the MIT License used for this project.


### PR DESCRIPTION
## Summary

Adds MIT License to bg-remover repository in preparation for open-source release and transition to Artisan Build maintenance.

## Changes

- **Added `LICENSE` file** with MIT License text
  - Copyright holder: Artisan Build (as this will be maintained by Artisan Build going forward)
  
- **Updated `README.md`** with licensing information:
  - Added "Dependencies" section documenting OpenCV (Apache 2.0)
  - Updated "License" section to reference LICENSE file
  - Clarified license compatibility (MIT + Apache 2.0)

## Background

Per client approval (Barry via Slack: "sounds good, go ahead and open it up"), bg-remover is being open-sourced as:

1. **Open-source Composer package** (`artisan-build/background-removal`)
   - Target: Laravel developers on Ubuntu/Alpine/macOS
   - Multi-platform binary distribution
   
2. **Internal API service** in Artisan Build Scalpels product
   - EXACT Sports and other clients will consume via API

## License Compatibility

✅ **MIT is compatible with OpenCV's Apache 2.0 License**

- OpenCV (only dependency) is Apache 2.0 (permissive)
- MIT license applies to bg-remover source code
- README documents both licenses clearly
- Full licensing assessment completed in work session

## Next Steps

After merge:
1. Make repository public
2. Fork to `artisan-build/bg-remover` organization
3. Begin Composer package development in new Artisan Build work session

---

**Related Work Session:** `Clients/EXACT Sports/Work/2026-01-08-bg-remover-ubuntu-deployment/`