### PR TITLE
Fix Laravel package issue repository reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,5 +227,5 @@ OpenCV is licensed under the Apache 2.0 License, which is compatible with the MI
 ## Contributing
 
 - Binary issues/features: Open in this repository
-- Laravel package issues: Open in [artisan-build/scalpels](https://github.com/artisan-build/scalpels)
+- Laravel package issues: Open in [artisan-build/scalpels.app](https://github.com/artisan-build/scalpels.app)
 - Community platform builds: See [FORKING.md](FORKING.md)


### PR DESCRIPTION
Corrects the repository reference for Laravel package issues from `artisan-build/scalpels` to `artisan-build/scalpels.app`.

The Laravel package is developed in `scalpels.app/packages/background-remover/` and split to `artisan-build/background-removal` for distribution. `artisan-build/scalpels` is the distributed package, not the development repository.