### PR TITLE
Add Linux ARM64 release build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ jobs:
     name: Build ${{ matrix.platform }}
     runs-on: ${{ matrix.runner }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - platform: ubuntu
@@ -63,7 +64,7 @@ jobs:
         if: matrix.platform == 'macos'
         run: |
           # Build for ARM64 (Apple Silicon) with ML support
-          make ML=1 TARGET=local OUTPUT=${{ matrix.output }}
+          make ML=1 TARGET=local OUTPUT=${{ matrix.output }} CXXFLAGS="-std=c++17 -O3 -Wall"
       
       # Verify binary
       - name: Verify binary

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,9 @@
 name: Build Multi-Platform Binaries
 
 on:
+  pull_request:
+    branches:
+      - main
   push:
     tags:
       - 'v*'
@@ -22,6 +25,12 @@ jobs:
             dockerfile: Dockerfile.ubuntu
             output: bg-remover-ubuntu-x86_64
 
+          - platform: linux-arm64
+            runner: ubuntu-24.04-arm
+            dockerfile: Dockerfile.ubuntu-arm64
+            output: bg-remover-linux-arm64
+            docker_platform: linux/arm64
+
           - platform: macos
             runner: macos-latest
             output: bg-remover-macos-arm64
@@ -34,9 +43,14 @@ jobs:
       - name: Build ${{ matrix.platform }} binary (Docker)
         if: matrix.platform != 'macos'
         run: |
-          docker build -f ${{ matrix.dockerfile }} -t bg-remover-${{ matrix.platform }} .
+          if [ -n "${{ matrix.docker_platform }}" ]; then
+            docker build --platform ${{ matrix.docker_platform }} -f ${{ matrix.dockerfile }} -t bg-remover-${{ matrix.platform }} .
+          else
+            docker build -f ${{ matrix.dockerfile }} -t bg-remover-${{ matrix.platform }} .
+          fi
           docker create --name extract bg-remover-${{ matrix.platform }}
           docker cp extract:/app/bg-remover ./${{ matrix.output }}
+          docker cp extract:/app/lib ./lib 2>/dev/null || true
           docker rm extract
       
       # macOS build (native)
@@ -62,6 +76,9 @@ jobs:
       - name: Generate SHA256 checksum
         run: |
           shasum -a 256 ${{ matrix.output }} > ${{ matrix.output }}.sha256
+          if [ -d lib ]; then
+            find lib -type f ! -name 'libonnxruntime.so' -exec shasum -a 256 {} \; >> ${{ matrix.output }}.sha256
+          fi
           cat ${{ matrix.output }}.sha256
       
       # Upload artifacts
@@ -72,6 +89,7 @@ jobs:
           path: |
             ${{ matrix.output }}
             ${{ matrix.output }}.sha256
+            lib/**
   
   release:
     name: Create Release
@@ -108,6 +126,12 @@ jobs:
           name: bg-remover-macos-arm64
           path: ./dist
 
+      - name: Download Linux ARM64 binary
+        uses: actions/download-artifact@v4
+        with:
+          name: bg-remover-linux-arm64
+          path: ./dist
+
       # Create combined checksums file
       - name: Create checksums.txt
         run: |
@@ -123,6 +147,8 @@ jobs:
           tag_name: ${{ steps.version.outputs.tag }}
           files: |
             dist/bg-remover-ubuntu-x86_64
+            dist/bg-remover-linux-arm64
+            dist/lib/libonnxruntime.so.1
             dist/bg-remover-macos-arm64
             dist/checksums.txt
           draft: false
@@ -138,6 +164,7 @@ jobs:
             | Platform | Binary | ML Support | Use Case |
             |----------|--------|------------|----------|
             | Ubuntu | `bg-remover-ubuntu-x86_64` | ✅ GrabCut + ML | Laravel Vapor & Forge |
+            | Linux ARM64 | `bg-remover-linux-arm64` | ✅ GrabCut + ML | Laravel Cloud workers |
             | macOS | `bg-remover-macos-arm64` | ✅ GrabCut + ML | Development (Apple Silicon) |
 
             ### Installation
@@ -145,6 +172,10 @@ jobs:
             ```bash
             # Download for your platform
             wget https://github.com/artisan-build/bg-remover/releases/download/${{ steps.version.outputs.tag }}/bg-remover-ubuntu-x86_64
+
+            # Linux ARM64 also needs the co-located ONNX Runtime library:
+            # mkdir -p lib
+            # wget -O lib/libonnxruntime.so.1 https://github.com/artisan-build/bg-remover/releases/download/${{ steps.version.outputs.tag }}/libonnxruntime.so.1
 
             # Verify checksum
             wget https://github.com/artisan-build/bg-remover/releases/download/${{ steps.version.outputs.tag }}/checksums.txt

--- a/Dockerfile.ubuntu-arm64
+++ b/Dockerfile.ubuntu-arm64
@@ -1,0 +1,91 @@
+FROM debian:12-slim AS build
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV ONNXRUNTIME_VERSION=1.19.2
+ENV OPENCV_VERSION=4.10.0
+
+WORKDIR /build
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    cmake \
+    g++ \
+    make \
+    ninja-build \
+    pkg-config \
+    wget \
+    unzip \
+    binutils \
+    file \
+    zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN wget -q "https://github.com/microsoft/onnxruntime/releases/download/v${ONNXRUNTIME_VERSION}/onnxruntime-linux-aarch64-${ONNXRUNTIME_VERSION}.tgz" \
+    && tar -xzf "onnxruntime-linux-aarch64-${ONNXRUNTIME_VERSION}.tgz" \
+    && mkdir -p /opt/onnxruntime/include/onnxruntime /opt/onnxruntime/lib \
+    && cp -r "onnxruntime-linux-aarch64-${ONNXRUNTIME_VERSION}/include/"* /opt/onnxruntime/include/onnxruntime/ \
+    && cp -r "onnxruntime-linux-aarch64-${ONNXRUNTIME_VERSION}/lib/"* /opt/onnxruntime/lib/ \
+    && rm -rf "onnxruntime-linux-aarch64-${ONNXRUNTIME_VERSION}"*
+
+RUN wget -q "https://github.com/opencv/opencv/archive/${OPENCV_VERSION}.zip" -O opencv.zip \
+    && unzip -q opencv.zip \
+    && cmake -S "opencv-${OPENCV_VERSION}" -B opencv-build -G Ninja \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX=/opt/opencv-static \
+        -DBUILD_SHARED_LIBS=OFF \
+        -DBUILD_LIST=core,imgcodecs,imgproc \
+        -DBUILD_EXAMPLES=OFF \
+        -DBUILD_opencv_apps=OFF \
+        -DBUILD_PERF_TESTS=OFF \
+        -DBUILD_TESTS=OFF \
+        -DBUILD_DOCS=OFF \
+        -DOPENCV_GENERATE_PKGCONFIG=ON \
+        -DOPENCV_ENABLE_NONFREE=OFF \
+        -DWITH_FFMPEG=OFF \
+        -DWITH_GSTREAMER=OFF \
+        -DWITH_GTK=OFF \
+        -DWITH_OPENEXR=OFF \
+        -DWITH_WEBP=OFF \
+        -DWITH_TIFF=OFF \
+        -DWITH_JASPER=OFF \
+        -DWITH_OPENJPEG=OFF \
+        -DWITH_PROTOBUF=OFF \
+        -DBUILD_JPEG=ON \
+        -DBUILD_PNG=ON \
+        -DBUILD_ZLIB=ON \
+    && cmake --build opencv-build --parallel \
+    && cmake --install opencv-build \
+    && rm -rf opencv.zip "opencv-${OPENCV_VERSION}" opencv-build
+
+WORKDIR /app
+
+COPY src/bg-remover.cpp src/
+
+RUN mkdir -p lib \
+    && cp -L /opt/onnxruntime/lib/libonnxruntime.so.${ONNXRUNTIME_VERSION} lib/libonnxruntime.so.1 \
+    && ln -s "libonnxruntime.so.1" lib/libonnxruntime.so \
+    && g++ -std=c++14 -O3 -Wall -DWITH_ML \
+        -I/opt/onnxruntime/include \
+        src/bg-remover.cpp \
+        -o bg-remover \
+        $(PKG_CONFIG_PATH=/opt/opencv-static/lib/pkgconfig pkg-config --cflags --libs --static opencv4) \
+        -L/app/lib -lonnxruntime \
+        -Wl,-rpath,'$ORIGIN/lib' \
+        -Wl,--enable-new-dtags \
+        -static-libstdc++ \
+        -static-libgcc \
+        -ldl -lpthread -lm \
+    && rm lib/libonnxruntime.so \
+    && strip bg-remover \
+    && file bg-remover \
+    && readelf -d bg-remover \
+    && ldd bg-remover
+
+FROM debian:12-slim
+
+WORKDIR /app
+
+COPY --from=build /app/bg-remover /app/bg-remover
+COPY --from=build /app/lib /app/lib
+
+CMD ["bash"]

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,12 @@ ifeq ($(TARGET),ubuntu)
     OUTPUT = bg-remover-ubuntu-x86_64
 endif
 
+ifeq ($(TARGET),linux-arm64)
+    # Linux ARM64 build (glibc)
+    DOCKERFILE = Dockerfile.ubuntu-arm64
+    OUTPUT = bg-remover-linux-arm64
+endif
+
 ifeq ($(TARGET),macos)
     # macOS build (universal binary)
     CXXFLAGS += -arch arm64 -arch x86_64
@@ -67,13 +73,25 @@ build-docker-ubuntu:
 	docker rm bg-remover-extract
 	@echo "✅ Built: bg-remover-ubuntu-x86_64"
 
+build-docker-linux-arm64:
+	docker build --platform linux/arm64 -f Dockerfile.ubuntu-arm64 -t bg-remover-linux-arm64 .
+	docker create --name bg-remover-arm64-extract bg-remover-linux-arm64
+	docker cp bg-remover-arm64-extract:/app/$(BINARY) ./bg-remover-linux-arm64
+	docker cp bg-remover-arm64-extract:/app/lib ./lib
+	docker rm bg-remover-arm64-extract
+	@echo "✅ Built: bg-remover-linux-arm64"
+
 # Convenience targets
 ubuntu: TARGET = ubuntu
 ubuntu: DOCKERFILE = Dockerfile.ubuntu
 ubuntu: build-docker-ubuntu
 
+linux-arm64: TARGET = linux-arm64
+linux-arm64: DOCKERFILE = Dockerfile.ubuntu-arm64
+linux-arm64: build-docker-linux-arm64
+
 # Clean
 clean:
 	rm -f $(BINARY) bg-remover-*
 
-.PHONY: all clean ubuntu build-docker-ubuntu
+.PHONY: all clean ubuntu linux-arm64 build-docker-ubuntu build-docker-linux-arm64


### PR DESCRIPTION
## Summary
- Adds a Debian 12 based `Dockerfile.ubuntu-arm64` that builds `bg-remover-linux-arm64` with ML support, static OpenCV, and a co-located ONNX Runtime library under `lib/`.
- Adds a `linux-arm64` GitHub Actions matrix entry on `ubuntu-24.04-arm`, including artifact/checksum/release wiring for the binary and `lib/libonnxruntime.so.1`.
- Adds a PR CI trigger so the full three-platform build matrix can run without creating a release.

## Linkage findings
Ground-truthed the current `bg-remover-ubuntu-x86_64` release artifact before choosing the arm64 strategy:

```text
/work/bg-remover-ubuntu-x86_64: ELF 64-bit LSB pie executable, x86-64, dynamically linked, stripped
NEEDED: libonnxruntime.so.1
NEEDED: libm.so.6
NEEDED: libc.so.6
NEEDED: ld-linux-x86-64.so.2
RUNPATH: [$ORIGIN:$ORIGIN/lib]
ldd: libonnxruntime.so.1 => not found
```

There are no dynamic `libopencv*` dependencies in the shipped x86_64 artifact, so OpenCV is genuinely statically baked into that release. The committed `Dockerfile.ubuntu` does not reflect that provenance, which is the known build-provenance debt. This PR discharges that debt for the new arm64 build by making the static OpenCV linkage explicit and reproducible.

## New arm64 build
- Base image: `debian:12-slim` so the build targets Debian 12 / glibc 2.36 compatibility.
- ONNX Runtime: pinned to Microsoft release asset `onnxruntime-linux-aarch64-1.19.2.tgz`.
- OpenCV: builds OpenCV 4.10.0 from source with `BUILD_SHARED_LIBS=OFF` and minimal modules `core,imgcodecs,imgproc`.
- Runtime layout: `bg-remover-linux-arm64` beside `lib/libonnxruntime.so.1`.
- Binary runpath: `RUNPATH [$ORIGIN/lib]`.

Build verification command:

```bash
docker build --platform linux/arm64 -f Dockerfile.ubuntu-arm64 -t bg-remover-linux-arm64 .
```

Build output excerpt:

```text
bg-remover: ELF 64-bit LSB pie executable, ARM aarch64, dynamically linked, interpreter /lib/ld-linux-aarch64.so.1
NEEDED: libonnxruntime.so.1
NEEDED: libm.so.6
NEEDED: libc.so.6
RUNPATH: [$ORIGIN/lib]
libonnxruntime.so.1 => /app/./lib/libonnxruntime.so.1
```

## Smoke test evidence
Runtime was a fresh `debian:12-slim` arm64 container, non-root, with zero package installs. Mounted assets were only:

```text
bg-remover-linux-arm64
lib/libonnxruntime.so.1
sample.ppm
u2net.onnx
```

Smoke command shape:

```bash
docker run --rm --platform linux/arm64 --user 65532:65532 \
  -v /tmp/bg-remover-arm64-bundle:/work -w /work debian:12-slim \
  sh -c 'set -eu; ldd ./bg-remover-linux-arm64; ./bg-remover-linux-arm64 --grabcut -i sample.ppm -o grabcut.png; ./bg-remover-linux-arm64 -i sample.ppm -o ml.png --model u2net.onnx; ls -l grabcut.png ml.png'
```

Output excerpt:

```text
libonnxruntime.so.1 => /work/./lib/libonnxruntime.so.1
Background removed successfully -> grabcut.png
Background removed successfully -> ml.png
-rw-r--r-- 1 65532 65532 449 grabcut.png
-rw-r--r-- 1 65532 65532 928 ml.png
```

PNG alpha validation:

```text
grabcut.png: 160x160, alpha min=0, max=255, transparent_pixels=19118
ml.png: 160x160, alpha min=0, max=255, transparent_pixels=19122
```

## CI
The PR should run the full build matrix:

- `ubuntu` on `ubuntu-latest`
- `linux-arm64` on `ubuntu-24.04-arm`
- `macos` on `macos-latest`