### PR TITLE
Build static Ubuntu x86_64 binary

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,54 +1,91 @@
-FROM ubuntu:22.04
+FROM debian:12-slim AS build
 
 ENV DEBIAN_FRONTEND=noninteractive
+ENV ONNXRUNTIME_VERSION=1.19.2
+ENV OPENCV_VERSION=4.10.0
+
+WORKDIR /build
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    cmake \
+    g++ \
+    make \
+    ninja-build \
+    pkg-config \
+    wget \
+    unzip \
+    binutils \
+    file \
+    zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN wget -q "https://github.com/microsoft/onnxruntime/releases/download/v${ONNXRUNTIME_VERSION}/onnxruntime-linux-x64-${ONNXRUNTIME_VERSION}.tgz" \
+    && tar -xzf "onnxruntime-linux-x64-${ONNXRUNTIME_VERSION}.tgz" \
+    && mkdir -p /opt/onnxruntime/include/onnxruntime /opt/onnxruntime/lib \
+    && cp -r "onnxruntime-linux-x64-${ONNXRUNTIME_VERSION}/include/"* /opt/onnxruntime/include/onnxruntime/ \
+    && cp -r "onnxruntime-linux-x64-${ONNXRUNTIME_VERSION}/lib/"* /opt/onnxruntime/lib/ \
+    && rm -rf "onnxruntime-linux-x64-${ONNXRUNTIME_VERSION}"*
+
+RUN wget -q "https://github.com/opencv/opencv/archive/${OPENCV_VERSION}.zip" -O opencv.zip \
+    && unzip -q opencv.zip \
+    && cmake -S "opencv-${OPENCV_VERSION}" -B opencv-build -G Ninja \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX=/opt/opencv-static \
+        -DBUILD_SHARED_LIBS=OFF \
+        -DBUILD_LIST=core,imgcodecs,imgproc \
+        -DBUILD_EXAMPLES=OFF \
+        -DBUILD_opencv_apps=OFF \
+        -DBUILD_PERF_TESTS=OFF \
+        -DBUILD_TESTS=OFF \
+        -DBUILD_DOCS=OFF \
+        -DOPENCV_GENERATE_PKGCONFIG=ON \
+        -DOPENCV_ENABLE_NONFREE=OFF \
+        -DWITH_FFMPEG=OFF \
+        -DWITH_GSTREAMER=OFF \
+        -DWITH_GTK=OFF \
+        -DWITH_OPENEXR=OFF \
+        -DWITH_WEBP=OFF \
+        -DWITH_TIFF=OFF \
+        -DWITH_JASPER=OFF \
+        -DWITH_OPENJPEG=OFF \
+        -DWITH_PROTOBUF=OFF \
+        -DBUILD_JPEG=ON \
+        -DBUILD_PNG=ON \
+        -DBUILD_ZLIB=ON \
+    && cmake --build opencv-build --parallel \
+    && cmake --install opencv-build \
+    && rm -rf opencv.zip "opencv-${OPENCV_VERSION}" opencv-build
 
 WORKDIR /app
 
-# Install OpenCV and build tools
-RUN apt-get update && apt-get install -y \
-    g++ \
-    make \
-    pkg-config \
-    libopencv-dev \
-    file \
-    wget \
-    ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install ONNX Runtime for ML support
-RUN mkdir -p /usr/local/include/onnxruntime /usr/local/lib && \
-    wget -q https://github.com/microsoft/onnxruntime/releases/download/v1.19.2/onnxruntime-linux-x64-1.19.2.tgz && \
-    tar -xzf onnxruntime-linux-x64-1.19.2.tgz && \
-    cp -r onnxruntime-linux-x64-1.19.2/include/* /usr/local/include/onnxruntime/ && \
-    cp -r onnxruntime-linux-x64-1.19.2/lib/* /usr/local/lib/ && \
-    ldconfig && \
-    rm -rf onnxruntime-linux-x64-1.19.2*
-
-# Create pkg-config file for ONNX Runtime
-RUN mkdir -p /usr/local/lib/pkgconfig && \
-    printf "prefix=/usr/local\n\
-exec_prefix=\${prefix}\n\
-libdir=\${exec_prefix}/lib\n\
-includedir=\${prefix}/include\n\n\
-Name: ONNX Runtime\n\
-Description: ONNX Runtime\n\
-Version: 1.19.2\n\
-Libs: -L\${libdir} -lonnxruntime\n\
-Cflags: -I\${includedir}\n" > /usr/local/lib/pkgconfig/onnxruntime.pc
-
-# Copy source file
 COPY src/bg-remover.cpp src/
-COPY Makefile .
 
-# Build the binary with ML support
-RUN make ML=1
+RUN mkdir -p lib \
+    && cp -L /opt/onnxruntime/lib/libonnxruntime.so.${ONNXRUNTIME_VERSION} lib/libonnxruntime.so.1 \
+    && ln -s "libonnxruntime.so.1" lib/libonnxruntime.so \
+    && g++ -std=c++14 -O3 -Wall -DWITH_ML \
+        -I/opt/onnxruntime/include \
+        src/bg-remover.cpp \
+        -o bg-remover \
+        $(PKG_CONFIG_PATH=/opt/opencv-static/lib/pkgconfig pkg-config --cflags --libs --static opencv4) \
+        -L/app/lib -lonnxruntime \
+        -Wl,-rpath,'$ORIGIN/lib' \
+        -Wl,--enable-new-dtags \
+        -static-libstdc++ \
+        -static-libgcc \
+        -ldl -lpthread -lm \
+    && rm lib/libonnxruntime.so \
+    && strip bg-remover \
+    && file bg-remover \
+    && readelf -d bg-remover \
+    && ldd bg-remover
 
-# Show what we built and its dependencies
-RUN echo "Binary info:" && \
-    ls -lh bg-remover && \
-    file bg-remover && \
-    echo "" && \
-    echo "Dependencies:" && \
-    ldd bg-remover
+FROM debian:12-slim
+
+WORKDIR /app
+
+COPY --from=build /app/bg-remover /app/bg-remover
+COPY --from=build /app/lib /app/lib
 
 CMD ["bash"]


### PR DESCRIPTION
## Summary
- Replace the Ubuntu x86_64 Docker build with the same Debian 12/static OpenCV build structure used by the arm64 Dockerfile.
- Fetch ONNX Runtime `onnxruntime-linux-x64-1.19.2.tgz`, co-locate `lib/libonnxruntime.so.1`, and link the binary with `$ORIGIN/lib` RUNPATH plus static libstdc++/libgcc.
- Leave the existing workflow extraction path unchanged: `/app/bg-remover` and `/app/lib`.

## Smoke Test Evidence
Built locally with Docker Desktop on Apple Silicon using `docker build --platform linux/amd64 -f Dockerfile.ubuntu -t bg-remover-ubuntu-static-test .`.

Clean runtime test used a fresh `debian:12-slim` amd64 container as non-root with only generic test tooling installed (`binutils`, `file`, `python3`, `wget`, `ca-certificates`) and no apt OpenCV packages.

`readelf -d ./bg-remover | grep NEEDED`:
```text
0x0000000000000001 (NEEDED)             Shared library: [libonnxruntime.so.1]
0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
0x0000000000000001 (NEEDED)             Shared library: [ld-linux-x86-64.so.2]
```
No `libopencv*`, `libstdc++`, or `libgcc_s` NEEDED entries on the binary.

`ldd ./bg-remover` confirms ONNX Runtime resolves through `$ORIGIN/lib`:
```text
libonnxruntime.so.1 => /work/./lib/libonnxruntime.so.1
```

GrabCut smoke tests:
```text
tiny-grabcut_exit=0
Background removed successfully -> tiny-grabcut.png
tiny-grabcut.png: png=true size=32x32 bit_depth=8 color_type=6

realistic-grabcut_exit=0
Background removed successfully -> realistic-grabcut.png
realistic-grabcut.png: png=true size=256x256 bit_depth=8 color_type=6
```

Tiny-image result: 32x32 GrabCut succeeds and writes a valid RGBA PNG, so no minimum-size failure was observed at 32x32.

ML smoke test used U2-Net ONNX from `https://github.com/danielgatis/rembg/releases/download/v0.0.0/u2net.onnx`:
```text
ml_exit=0
Background removed successfully -> realistic-ml.png
realistic-ml.png: png=true size=256x256 bit_depth=8 color_type=6
```