### PR TITLE
Document current binary runtime contract

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       
       # Linux build (Ubuntu) via Docker
       - name: Build ${{ matrix.platform }} binary (Docker)
@@ -77,20 +77,16 @@ jobs:
       - name: Generate SHA256 checksum
         run: |
           shasum -a 256 ${{ matrix.output }} > ${{ matrix.output }}.sha256
-          if [ -d lib ]; then
-            find lib -type f ! -name 'libonnxruntime.so' -exec shasum -a 256 {} \; >> ${{ matrix.output }}.sha256
-          fi
           cat ${{ matrix.output }}.sha256
       
       # Upload artifacts
       - name: Upload binary artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ${{ matrix.output }}
           path: |
             ${{ matrix.output }}
             ${{ matrix.output }}.sha256
-            lib/**
   
   release:
     name: Create Release
@@ -102,7 +98,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Set version variable
       - name: Set version
@@ -116,19 +112,19 @@ jobs:
 
       # Download all artifacts
       - name: Download Ubuntu binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: bg-remover-ubuntu-x86_64
           path: ./dist
 
       - name: Download macOS binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: bg-remover-macos-arm64
           path: ./dist
 
       - name: Download Linux ARM64 binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: bg-remover-linux-arm64
           path: ./dist
@@ -143,13 +139,12 @@ jobs:
 
       # Create GitHub Release
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.version.outputs.tag }}
           files: |
             dist/bg-remover-ubuntu-x86_64
             dist/bg-remover-linux-arm64
-            dist/lib/libonnxruntime.so.1
             dist/bg-remover-macos-arm64
             dist/checksums.txt
           draft: false
@@ -158,25 +153,27 @@ jobs:
           body: |
             ## BG Remover ${{ steps.version.outputs.tag }}
 
-            Multi-platform background removal binaries with **ML support enabled**. Use optimized OpenCV GrabCut by default, or switch to deep learning models (U2-Net, RMBG) with `--ml` flag for 80-95% better quality on complex images.
+            Multi-platform background removal binaries with **ML mode enabled by default**. Default ML mode requires `--model <path>`; pass `--grabcut` to opt out to OpenCV GrabCut. `--ml` is accepted but is a no-op because ML is already the default.
 
             ### Downloads
 
-            | Platform | Binary | ML Support | Use Case |
-            |----------|--------|------------|----------|
-            | Ubuntu | `bg-remover-ubuntu-x86_64` | ✅ GrabCut + ML | Laravel Vapor & Forge |
-            | Linux ARM64 | `bg-remover-linux-arm64` | ✅ GrabCut + ML | Laravel Cloud workers |
-            | macOS | `bg-remover-macos-arm64` | ✅ GrabCut + ML | Development (Apple Silicon) |
+            | Platform | Binary | Runtime Library | Use Case |
+            |----------|--------|-----------------|----------|
+            | Linux x86_64 | `bg-remover-ubuntu-x86_64` | ONNX Runtime `onnxruntime-linux-x64-1.19.2` | Forge / glibc servers |
+            | Linux ARM64 | `bg-remover-linux-arm64` | ONNX Runtime `onnxruntime-linux-aarch64-1.19.2` | Laravel Cloud workers |
+            | macOS ARM64 | `bg-remover-macos-arm64` | Homebrew `opencv` and `onnxruntime` | Development (Apple Silicon) |
 
             ### Installation
 
             ```bash
-            # Download for your platform
+            # Download the binary for your platform
             wget https://github.com/artisan-build/bg-remover/releases/download/${{ steps.version.outputs.tag }}/bg-remover-ubuntu-x86_64
 
-            # Linux ARM64 also needs the co-located ONNX Runtime library:
-            # mkdir -p lib
-            # wget -O lib/libonnxruntime.so.1 https://github.com/artisan-build/bg-remover/releases/download/${{ steps.version.outputs.tag }}/libonnxruntime.so.1
+            # Linux also needs the arch-matching ONNX Runtime 1.19.2 library.
+            # Download one from https://github.com/microsoft/onnxruntime/releases/tag/v1.19.2:
+            # - onnxruntime-linux-x64-1.19.2.tgz for bg-remover-ubuntu-x86_64
+            # - onnxruntime-linux-aarch64-1.19.2.tgz for bg-remover-linux-arm64
+            # Then place libonnxruntime.so.1 next to the binary or under ./lib/.
 
             # Verify checksum
             wget https://github.com/artisan-build/bg-remover/releases/download/${{ steps.version.outputs.tag }}/checksums.txt
@@ -185,12 +182,16 @@ jobs:
             # Make executable
             chmod +x bg-remover-ubuntu-x86_64
 
-            # Run with GrabCut (default)
-            ./bg-remover-ubuntu-x86_64 -i input.jpg -o output.png
+            # Run with ML mode (default)
+            ./bg-remover-ubuntu-x86_64 -i input.jpg -o output.png --model /path/to/u2net.onnx
 
-            # Run with ML models for better quality
-            ./bg-remover-ubuntu-x86_64 -i input.jpg -o output.png --ml --model /path/to/u2net.onnx
+            # Opt out to GrabCut; libonnxruntime.so.1 is still required at load time
+            ./bg-remover-ubuntu-x86_64 -i input.jpg -o output.png --grabcut
             ```
+
+            ### Runtime Notes
+
+            Linux binaries statically bundle OpenCV, libstdc++, and libgcc. They dynamically load only `libonnxruntime.so.1` plus glibc system libraries, with RUNPATH `$ORIGIN:$ORIGIN/lib`. The Linux glibc floor is 2.34. macOS builds are development-only and dynamically link Homebrew OpenCV and ONNX Runtime.
 
             ### Checksums
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
@@ -54,4 +54,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/sdk#command-line for available options
           claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
@@ -47,4 +47,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/sdk#command-line for available options
           # claude_args: '--model claude-opus-4-1-20250805 --allowed-tools Bash(gh pr:*)'
-

--- a/FORKING.md
+++ b/FORKING.md
@@ -2,390 +2,178 @@
 
 ## Overview
 
-Artisan Build maintains bg-remover binaries for the platforms we actively use in production and development:
+Artisan Build maintains official `bg-remover` binaries for the platforms used by this package:
 
-- **Alpine Linux (x86_64)** - Laravel Vapor deployments
-- **Ubuntu (x86_64)** - Laravel Forge servers
-- **macOS (Universal: ARM64 + x86_64)** - Development machines
+- **Linux x86_64**: `bg-remover-ubuntu-x86_64`, built by `Dockerfile.ubuntu`
+- **Linux arm64**: `bg-remover-linux-arm64`, built by `Dockerfile.ubuntu-arm64`
+- **macOS arm64**: `bg-remover-macos-arm64`, built natively on macOS with Homebrew dependencies
 
-If you need bg-remover on a different platform, you're welcome to fork this repository and maintain your own build. This document explains how.
+The Linux builds are Debian 12/glibc builds with a `GLIBC_2.34` floor. They statically bundle OpenCV, libstdc++, and libgcc, and dynamically load the architecture-matching ONNX Runtime 1.19.2 `libonnxruntime.so.1` from `$ORIGIN` or `$ORIGIN/lib`.
 
 ## When to Fork
 
-Fork this repository if you need bg-remover on:
+Fork this repository if you need a platform or packaging model that is not produced by the official release workflow, such as:
 
-- **Windows** (any architecture)
-- **Other Linux distributions** (Arch, Fedora, CentOS, Debian, etc.)
-- **ARM-based Linux** (Raspberry Pi, AWS Graviton, other ARM servers)
-- **BSD variants** (FreeBSD, OpenBSD, NetBSD)
-- **Different architectures** (ARM32, RISC-V, etc.)
-- **Static binaries** for your specific use case
-- **Specific OpenCV versions** not available in our builds
+- Windows
+- Alpine/musl
+- Linux ARM32, RISC-V, or other architectures
+- BSD variants
+- Different glibc floors
+- Fully self-contained ONNX Runtime packaging
+- Different OpenCV or ONNX Runtime versions
+- A distribution-specific package format
 
-## Why We Don't Maintain These
+Linux arm64 is no longer a community-only target; it is officially supported for Laravel Cloud workers and other glibc >= 2.34 arm64 hosts.
 
-We follow a simple maintenance policy: **we only maintain what we use**. This ensures:
+## Current Build Pipeline
 
-- High-quality builds for supported platforms
-- Timely updates and security patches
-- Proper testing on real workloads
-- Sustainable maintenance burden
+Before creating a fork, review the real upstream build pipeline:
 
-We can't maintain platforms we don't actively use because we can't properly test them or respond to platform-specific issues.
+- `Dockerfile.ubuntu` downloads ONNX Runtime linux-x64 1.19.2, builds OpenCV 4.10.0 static libraries, and links `bg-remover-ubuntu-x86_64` with static OpenCV plus dynamic ONNX Runtime.
+- `Dockerfile.ubuntu-arm64` does the same for ONNX Runtime linux-aarch64 1.19.2 and outputs `bg-remover-linux-arm64`.
+- `.github/workflows/build.yml` builds those two Linux targets with Docker and builds `bg-remover-macos-arm64` natively after `brew install opencv onnxruntime pkg-config`.
+- The release publishes binaries and checksums. Consumers should fetch the ONNX Runtime package matching their platform from Microsoft and co-locate `libonnxruntime.so.1` with the binary.
+
+Do not base a fork on stale Alpine, universal macOS, or system-OpenCV assumptions.
 
 ## How to Fork and Build
 
-### Step 1: Fork the Repository
-
-1. Click "Fork" on the [bg-remover repository](https://github.com/artisan-build/bg-remover)
-2. Clone your fork:
-   ```bash
-   git clone https://github.com/YOUR-USERNAME/bg-remover.git
-   cd bg-remover
-   ```
-
-### Step 2: Create a Dockerfile for Your Platform
-
-Create a new Dockerfile for your target platform. Use our existing Dockerfiles as templates:
-
-**Example: `Dockerfile.windows` (hypothetical)**
-
-```dockerfile
-# Use Windows Server Core as base
-FROM mcr.microsoft.com/windows/servercore:ltsc2022
-
-# Install Visual Studio Build Tools and vcpkg for OpenCV
-# (Windows-specific setup here)
-
-WORKDIR /app
-
-# Copy source
-COPY src/bg-remover.cpp src/
-COPY Makefile .
-
-# Build (adjust for Windows toolchain)
-RUN cl.exe src/bg-remover.cpp /link opencv_world.lib
-
-CMD ["cmd"]
-```
-
-**Example: `Dockerfile.arch` (Arch Linux)**
-
-```dockerfile
-FROM archlinux:latest
-
-RUN pacman -Syu --noconfirm && \
-    pacman -S --noconfirm gcc make pkgconf opencv
-
-WORKDIR /app
-
-COPY src/bg-remover.cpp src/
-COPY Makefile .
-
-RUN make
-
-CMD ["bash"]
-```
-
-### Step 3: Update the Makefile
-
-Add your platform to the Makefile:
-
-```makefile
-ifeq ($(TARGET),windows)
-    DOCKERFILE = Dockerfile.windows
-    OUTPUT = bg-remover-windows-x86_64.exe
-endif
-
-ifeq ($(TARGET),arch)
-    DOCKERFILE = Dockerfile.arch
-    OUTPUT = bg-remover-arch-x86_64
-endif
-
-# Add build targets
-build-docker-windows:
-	docker build -f Dockerfile.windows -t bg-remover-windows .
-	# Extract binary...
-
-build-docker-arch:
-	docker build -f Dockerfile.arch -t bg-remover-arch .
-	# Extract binary...
-
-windows: TARGET = windows
-windows: build-docker-windows
-
-arch: TARGET = arch
-arch: build-docker-arch
-```
-
-### Step 4: Test Your Build Locally
+### Step 1: Fork The Repository
 
 ```bash
-# Build for your platform
-make windows
-# or
-make arch
-
-# Test the binary
-./bg-remover-windows-x86_64.exe -i test.jpg -o output.png
+git clone https://github.com/YOUR-USERNAME/bg-remover.git
+cd bg-remover
 ```
 
-Verify:
-- ✅ Binary executes without errors
-- ✅ Dependencies are satisfied or bundled
-- ✅ Output PNG has transparent background
-- ✅ Works on a clean system (not just your dev machine)
+Keep the upstream remote handy:
 
-### Step 5: Set Up GitHub Actions (Optional but Recommended)
-
-Add your platform to `.github/workflows/build.yml`:
-
-```yaml
-strategy:
-  matrix:
-    include:
-      # Existing platforms...
-      
-      - platform: windows
-        runner: windows-latest
-        dockerfile: Dockerfile.windows
-        output: bg-remover-windows-x86_64.exe
-      
-      - platform: arch
-        runner: ubuntu-latest
-        dockerfile: Dockerfile.arch
-        output: bg-remover-arch-x86_64
+```bash
+git remote add upstream https://github.com/artisan-build/bg-remover.git
 ```
 
-This automatically builds and attaches binaries to releases.
+### Step 2: Pick Your Runtime Contract
 
-### Step 6: Create a Release
+Document these decisions before changing CI:
 
-1. Tag a version in your fork:
-   ```bash
-   git tag -a v1.0.0-windows -m "Windows build"
-   git push origin v1.0.0-windows
-   ```
+- Target OS and architecture
+- glibc, musl, or non-Linux runtime assumptions
+- Whether OpenCV is static or dynamic
+- Whether ONNX Runtime is static, bundled, co-located, or provided by the host
+- Binary and library asset names
+- Minimum supported OS version
 
-2. GitHub Actions will build and attach your binary to the release
+The official Linux contract is static OpenCV plus dynamic `libonnxruntime.so.1`. If your fork changes that contract, make it explicit in your README and release notes.
 
-3. Or manually create a release and upload the binary
+### Step 3: Add A Build Definition
+
+Use the official Dockerfiles as templates for Linux-like targets. For example, a musl or older-glibc fork should include a new Dockerfile rather than overloading `Dockerfile.ubuntu`.
+
+For non-Linux targets, use the native toolchain for that platform and ensure the C++ source is compiled with `-DWITH_ML` if you want the same default ML behavior as official builds.
+
+### Step 4: Update Build Helpers
+
+If you add a Makefile target, keep it specific and avoid changing official targets:
+
+```makefile
+ifeq ($(TARGET),my-platform)
+    DOCKERFILE = Dockerfile.my-platform
+    OUTPUT = bg-remover-my-platform
+endif
+
+build-docker-my-platform:
+	docker build -f Dockerfile.my-platform -t bg-remover-my-platform .
+	docker create --name bg-remover-my-platform-extract bg-remover-my-platform
+	docker cp bg-remover-my-platform-extract:/app/bg-remover ./bg-remover-my-platform
+	docker rm bg-remover-my-platform-extract
+```
+
+### Step 5: Test The Binary
+
+Verify on a clean host or container, not just the build machine:
+
+- The binary starts and prints `--help`.
+- Default ML mode fails clearly without `--model` and succeeds with a valid ONNX model.
+- `--grabcut` succeeds without a model.
+- Required dynamic libraries are present and documented.
+- Output is a PNG with alpha.
+- Checksums are published for every asset.
+
+For Linux, inspect dynamic dependencies with `readelf -d` and confirm they match your documented contract.
+
+### Step 6: Set Up GitHub Actions
+
+Add your target to a fork-specific workflow or matrix entry. If you publish runtime libraries, avoid ambiguous names: architecture-specific libraries must have architecture-specific asset names, or your release notes must tell users to fetch the correct upstream ONNX Runtime package.
 
 ### Step 7: Document Your Fork
 
-Update your fork's README.md:
+Your fork README should include:
 
-```markdown
-# BG Remover - Windows Fork
+- Maintainer and repository URL
+- Target OS/architecture
+- Runtime library contract
+- Exact ONNX Runtime and OpenCV versions
+- Installation and co-location instructions
+- Example ML and GrabCut invocations
+- Relationship to upstream [artisan-build/bg-remover](https://github.com/artisan-build/bg-remover)
 
-This is a community-maintained fork providing Windows builds of bg-remover.
+## Adding Your Fork To The Community List
 
-**Maintained by:** [@your-username](https://github.com/your-username)
+Once your fork is stable and tested, submit a PR to add it to the community builds section in `README.md`.
 
-**Platform:** Windows Server 2019+, Windows 10+
+In your PR description, include:
 
-**Download:** See [Releases](https://github.com/your-username/bg-remover/releases)
-
-**Upstream:** [artisan-build/bg-remover](https://github.com/artisan-build/bg-remover)
-
-## Installation
-
-1. Download `bg-remover-windows-x86_64.exe` from releases
-2. Place in your PATH or project directory
-3. Run: `bg-remover-windows-x86_64.exe -i input.jpg -o output.png`
-
-## Maintenance
-
-This fork is maintained independently. For issues specific to Windows builds, please open issues in this repository.
-
-For core functionality issues, please check the [upstream repository](https://github.com/artisan-build/bg-remover).
-```
-
-## Adding Your Fork to the Community List
-
-Once your fork is stable and tested, submit a PR to the main repository to add your fork to the README:
-
-### Step 1: Fork the Main Repository (if you haven't)
-
-### Step 2: Edit README.md
-
-Find the "Unsupported Platforms" section and update it:
-
-```markdown
-## Community-Maintained Platform Builds
-
-The following community members maintain builds for additional platforms:
-
-| Platform | Maintainer | Repository | Status |
-|----------|------------|------------|--------|
-| Windows (x86_64) | [@your-username](https://github.com/your-username) | [your-username/bg-remover](https://github.com/your-username/bg-remover) | Active |
-| Arch Linux | [@other-user](https://github.com/other-user) | [other-user/bg-remover](https://github.com/other-user/bg-remover) | Active |
-```
-
-### Step 3: Submit a Pull Request
-
-```bash
-git checkout -b add-windows-fork
-# Make your changes
-git commit -m "Add Windows fork to community platforms"
-git push origin add-windows-fork
-gh pr create --title "Add Windows fork to community platforms"
-```
-
-In your PR description:
 - Link to your fork
-- Confirm you'll maintain it
-- Note your testing environment
-- Provide example usage
+- Platform and architecture
+- Runtime dependency contract
+- How you test releases
+- Confirmation that you will maintain platform-specific issues in your fork
 
 ## Maintenance Expectations
 
-### What We'll Do (Artisan Build)
+Artisan Build will:
 
-- ✅ Link to your fork in our README
-- ✅ Direct users to your fork for your platform
-- ✅ Keep the core C++ code compatible when possible
+- Link to active community forks when useful.
+- Keep core C++ changes reasonably portable when possible.
+- Review documentation-only PRs for community platform listings.
 
-### What We Won't Do
+Artisan Build will not:
 
-- ❌ Debug platform-specific issues
-- ❌ Test on your platform
-- ❌ Provide support for your builds
-- ❌ Merge platform-specific code that breaks our builds
-- ❌ Take over maintenance if you stop
+- Debug platform-specific build or runtime failures in your fork.
+- Test unsupported platforms.
+- Merge changes that break official Linux x86_64, Linux arm64, or macOS arm64 builds.
+- Take over maintenance if a community fork becomes inactive.
 
-### What You're Responsible For
+You are responsible for:
 
-- ✅ Keeping your fork up to date with upstream
-- ✅ Testing on your target platform
-- ✅ Responding to issues in your fork
-- ✅ Security updates for your platform
-- ✅ Maintaining build infrastructure (Dockerfiles, CI/CD)
+- Keeping your fork up to date with upstream.
+- Testing on the target platform.
+- Responding to issues for your platform.
+- Updating runtime libraries and documenting security-sensitive dependency changes.
+- Maintaining your build infrastructure.
 
 ## Merging Upstream Changes
 
-Stay up to date with the main repository:
-
 ```bash
-# Add upstream remote (once)
-git remote add upstream https://github.com/artisan-build/bg-remover.git
-
-# Fetch upstream changes
 git fetch upstream
-
-# Merge into your main branch
 git checkout main
 git merge upstream/main
-
-# Resolve any conflicts
-# Test your build
 make your-platform
-
-# Push to your fork
 git push origin main
 ```
 
-## Tips for Success
-
-### 1. Start Small
-Get a basic build working before adding features.
-
-### 2. Use Docker When Possible
-Docker ensures reproducible builds and makes CI/CD easier.
-
-### 3. Document Everything
-Your users will have different setups. Clear documentation prevents issues.
-
-### 4. Automate Builds
-GitHub Actions or similar CI/CD ensures consistency.
-
-### 5. Test Thoroughly
-- Test on clean systems (not just your dev machine)
-- Test with different image formats
-- Test error cases (missing files, invalid images)
-
-### 6. Communicate Status
-If you can't maintain the fork anymore, update your README and notify us so we can remove the link.
-
-## Example: Raspberry Pi (ARM64)
-
-Here's a complete example for Raspberry Pi:
-
-**Dockerfile.raspberrypi**
-```dockerfile
-FROM arm64v8/ubuntu:22.04
-
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update && apt-get install -y \
-    g++ make pkg-config libopencv-dev
-
-WORKDIR /app
-
-COPY src/bg-remover.cpp src/
-COPY Makefile .
-
-RUN make
-
-CMD ["bash"]
-```
-
-**Build and test:**
-```bash
-# Build on Raspberry Pi or via QEMU
-docker build -f Dockerfile.raspberrypi -t bg-remover-rpi .
-
-# Extract binary
-docker create --name rpi-extract bg-remover-rpi
-docker cp rpi-extract:/app/bg-remover ./bg-remover-raspberrypi-arm64
-docker rm rpi-extract
-
-# Test
-./bg-remover-raspberrypi-arm64 -i test.jpg -o output.png
-```
-
-## Getting Help
-
-### For Platform-Specific Issues
-- Ask in forums/communities for your platform
-- Check OpenCV installation guides for your OS
-- Review Docker documentation for your base image
-
-### For Core Functionality Issues
-- Open an issue in the [main repository](https://github.com/artisan-build/bg-remover/issues)
-- Check if it reproduces on officially supported platforms first
-
-### For Maintenance Questions
-- See this document
-- Look at how we maintain our platforms
-- Ask questions in GitHub Discussions
+Use non-interactive Git commands in automation, and never overwrite upstream changes without reviewing them.
 
 ## Legal
 
 Your fork must comply with:
-- **bg-remover's MIT License** - Keep the license file and attribution
-- **OpenCV's Apache 2.0 License** - Acknowledge OpenCV usage
+
+- `bg-remover`'s MIT License
+- OpenCV's Apache 2.0 License
+- ONNX Runtime's MIT License
 - Any additional platform-specific license requirements
 
-When distributing binaries, include LICENSE files and attributions.
+When distributing binaries, include required licenses and attribution notices.
 
-## Summary
+## Questions
 
-1. ✅ Fork the repository
-2. ✅ Create Dockerfile for your platform
-3. ✅ Update Makefile with build targets
-4. ✅ Test thoroughly on your platform
-5. ✅ Set up GitHub Actions (optional)
-6. ✅ Create releases with binaries
-7. ✅ Document your fork
-8. ✅ Submit PR to add to community list
-9. ✅ Maintain your fork independently
-10. ✅ Stay up to date with upstream
-
-We appreciate community contributions! While we can't maintain every platform, we're happy to support community members who do.
-
----
-
-**Questions?** Open a discussion in the [main repository](https://github.com/artisan-build/bg-remover/discussions).
-
-**Ready to contribute?** We'd love to link to your fork!
+Open a discussion or issue in the main repository for core functionality questions: [artisan-build/bg-remover](https://github.com/artisan-build/bg-remover).

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -1,51 +1,62 @@
 # BG-Remover Integration Guide
 
-This document explains how to integrate the bg-remover background removal tool into your application.
+This document explains how to integrate the `bg-remover` CLI into an application or deployment pipeline.
 
 ## Overview
 
-`bg-remover` is a command-line tool that removes backgrounds from images using OpenCV's GrabCut algorithm. It accepts an input image and outputs a PNG file with a transparent background.
+`bg-remover` removes image backgrounds and writes a PNG with an alpha channel. Official binaries default to ML segmentation and require `--model <path>`. Use `--grabcut` to opt out to OpenCV GrabCut.
 
 ## Prerequisites
 
-- The `bg-remover` binary must be available on your system
-- Input images should be in common formats (JPEG, PNG, BMP, TIFF, etc.)
-- Sufficient disk space for output files (PNG with alpha channel)
+- A supported `bg-remover` binary.
+- Linux x86_64 or Linux arm64 runtime with glibc >= 2.34.
+- For Linux, ONNX Runtime 1.19.2 `libonnxruntime.so.1` matching the binary architecture.
+- For macOS development, `brew install opencv onnxruntime pkg-config`.
+- Input images in common OpenCV-readable formats such as JPEG, PNG, BMP, or TIFF.
+
+Linux binaries statically bundle OpenCV, libstdc++, and libgcc. They still dynamically link `libonnxruntime.so.1`, resolved via `$ORIGIN:$ORIGIN/lib`; place that file next to the binary or in a sibling `lib/` directory. The ONNX Runtime library is required at process load time even when running `--grabcut`.
 
 ## Command-Line Interface
 
-### Basic Usage
-
 ```bash
-./bg-remover -i <input_path> -o <output_path>
-```
+# Default ML mode
+./bg-remover -i <input_path> -o <output_path> --model <model_path>
 
-### Parameters
+# GrabCut opt-out mode
+./bg-remover -i <input_path> -o <output_path> --grabcut
+```
 
 | Parameter | Required | Description | Example |
 |-----------|----------|-------------|---------|
-| `-i` | Yes | Path to input image file | `-i input.jpg` |
-| `-o` | Yes | Path to output PNG file | `-o output.png` |
+| `-i, --input` | Yes | Input image path, or `-` for stdin | `-i input.jpg` |
+| `-o, --output` | Yes | Output PNG path, or `-` for stdout | `-o output.png` |
+| `--model` | For ML mode | ONNX model path | `--model u2net.onnx` |
+| `--grabcut` | No | Use OpenCV GrabCut instead of ML | `--grabcut` |
+| `--ml` | No | No-op in official binaries because ML is already default | `--ml` |
+| `-q, --quality` | No | GrabCut preset: `fast`, `balanced`, `quality` | `-q quality` |
+| `-n, --iterations` | No | GrabCut iterations, 1-20 | `-n 12` |
+| `-m, --margin` | No | GrabCut edge margin/inset in pixels | `-m 20` |
+| `-e, --edge-mode` | No | GrabCut edge refinement: `blur`, `bilateral`, `guided` | `-e guided` |
 
-### Exit Codes
+## Exit Codes
 
 | Code | Meaning |
 |------|---------|
-| 0 | Success - background removed and saved |
-| Non-zero | Error occurred (file not found, invalid image, etc.) |
+| 0 | Success; background removed and saved |
+| Non-zero | Error occurred, such as missing input, invalid image, missing model, or missing runtime library |
 
 ## Integration Examples
 
-### 1. Shell Script Integration
+### Shell Script
 
 ```bash
 #!/bin/bash
 
 INPUT_IMAGE="$1"
 OUTPUT_IMAGE="$2"
+MODEL_PATH="/app/models/u2net.onnx"
 
-# Run bg-remover
-./bg-remover -i "$INPUT_IMAGE" -o "$OUTPUT_IMAGE"
+./bg-remover -i "$INPUT_IMAGE" -o "$OUTPUT_IMAGE" --model "$MODEL_PATH"
 
 if [ $? -eq 0 ]; then
     echo "Background removed successfully: $OUTPUT_IMAGE"
@@ -55,325 +66,130 @@ else
 fi
 ```
 
-### 2. Python Integration
+### Python
 
 ```python
-import subprocess
 import os
-from pathlib import Path
+import subprocess
 
-def remove_background(input_path, output_path, bg_remover_binary="./bg-remover"):
-    """
-    Remove background from an image using bg-remover.
-
-    Args:
-        input_path: Path to input image
-        output_path: Path to output PNG file
-        bg_remover_binary: Path to bg-remover executable
-
-    Returns:
-        bool: True if successful, False otherwise
-    """
-    # Validate input exists
+def remove_background(input_path, output_path, model_path, binary_path="./bg-remover"):
     if not os.path.exists(input_path):
         raise FileNotFoundError(f"Input file not found: {input_path}")
 
-    # Ensure output directory exists
     output_dir = os.path.dirname(output_path)
     if output_dir:
         os.makedirs(output_dir, exist_ok=True)
 
-    # Run bg-remover
-    try:
-        result = subprocess.run(
-            [bg_remover_binary, "-i", input_path, "-o", output_path],
-            capture_output=True,
-            text=True,
-            check=True
-        )
-        return os.path.exists(output_path)
-    except subprocess.CalledProcessError as e:
-        print(f"Error: {e.stderr}")
-        return False
+    subprocess.run([
+        binary_path,
+        "-i", input_path,
+        "-o", output_path,
+        "--model", model_path,
+    ], check=True)
 
-# Example usage
-if __name__ == "__main__":
-    success = remove_background("photo.jpg", "photo_no_bg.png")
-    if success:
-        print("Background removed successfully!")
+    return os.path.exists(output_path)
 ```
 
-### 3. Node.js Integration
+### Node.js
 
 ```javascript
 const { spawn } = require('child_process');
-const fs = require('fs').promises;
-const path = require('path');
 
-/**
- * Remove background from an image using bg-remover
- * @param {string} inputPath - Path to input image
- * @param {string} outputPath - Path to output PNG file
- * @param {string} binaryPath - Path to bg-remover binary (default: './bg-remover')
- * @returns {Promise<boolean>} True if successful
- */
-async function removeBackground(inputPath, outputPath, binaryPath = './bg-remover') {
-    return new Promise((resolve, reject) => {
-        // Ensure output directory exists
-        const outputDir = path.dirname(outputPath);
-        if (outputDir) {
-            fs.mkdir(outputDir, { recursive: true }).catch(() => {});
-        }
+function removeBackground(inputPath, outputPath, modelPath, binaryPath = './bg-remover') {
+  return new Promise((resolve, reject) => {
+    const child = spawn(binaryPath, [
+      '-i', inputPath,
+      '-o', outputPath,
+      '--model', modelPath,
+    ]);
 
-        const process = spawn(binaryPath, ['-i', inputPath, '-o', outputPath]);
-
-        let stderr = '';
-
-        process.stderr.on('data', (data) => {
-            stderr += data.toString();
-        });
-
-        process.on('close', (code) => {
-            if (code === 0) {
-                resolve(true);
-            } else {
-                reject(new Error(`bg-remover failed with code ${code}: ${stderr}`));
-            }
-        });
-
-        process.on('error', (err) => {
-            reject(new Error(`Failed to start bg-remover: ${err.message}`));
-        });
+    let stderr = '';
+    child.stderr.on('data', data => { stderr += data.toString(); });
+    child.on('close', code => {
+      code === 0 ? resolve(true) : reject(new Error(`bg-remover failed: ${stderr}`));
     });
+    child.on('error', reject);
+  });
 }
-
-// Example usage
-removeBackground('photo.jpg', 'photo_no_bg.png')
-    .then(() => console.log('Background removed successfully!'))
-    .catch(err => console.error('Error:', err.message));
 ```
 
-### 4. PHP Integration
+### PHP / Laravel
 
 ```php
-<?php
+use Illuminate\Support\Facades\Process;
 
-/**
- * Remove background from an image using bg-remover
- *
- * @param string $inputPath Path to input image
- * @param string $outputPath Path to output PNG file
- * @param string $binaryPath Path to bg-remover binary
- * @return bool True if successful, false otherwise
- */
-function removeBackground($inputPath, $outputPath, $binaryPath = './bg-remover') {
-    // Validate input
-    if (!file_exists($inputPath)) {
-        throw new Exception("Input file not found: $inputPath");
-    }
-
-    // Ensure output directory exists
-    $outputDir = dirname($outputPath);
-    if ($outputDir && !is_dir($outputDir)) {
-        mkdir($outputDir, 0755, true);
-    }
-
-    // Escape arguments for shell safety
-    $cmd = sprintf(
-        '%s -i %s -o %s',
-        escapeshellarg($binaryPath),
-        escapeshellarg($inputPath),
-        escapeshellarg($outputPath)
-    );
-
-    // Execute command
-    exec($cmd, $output, $returnCode);
-
-    return $returnCode === 0 && file_exists($outputPath);
-}
-
-// Example usage
-try {
-    $success = removeBackground('photo.jpg', 'photo_no_bg.png');
-    if ($success) {
-        echo "Background removed successfully!\n";
-    } else {
-        echo "Failed to remove background\n";
-    }
-} catch (Exception $e) {
-    echo "Error: " . $e->getMessage() . "\n";
-}
-?>
+Process::run([
+    base_path('bin/bg-remover-linux-arm64'),
+    '-i', $inputPath,
+    '-o', $outputPath,
+    '--model', base_path('models/u2net.onnx'),
+])->throw();
 ```
 
-### 5. Go Integration
+### Go
 
 ```go
-package main
-
-import (
-    "fmt"
-    "os"
-    "os/exec"
-    "path/filepath"
+cmd := exec.Command(
+    "./bg-remover",
+    "-i", inputPath,
+    "-o", outputPath,
+    "--model", modelPath,
 )
-
-// RemoveBackground removes the background from an image using bg-remover
-func RemoveBackground(inputPath, outputPath, binaryPath string) error {
-    // Validate input exists
-    if _, err := os.Stat(inputPath); os.IsNotExist(err) {
-        return fmt.Errorf("input file not found: %s", inputPath)
-    }
-
-    // Ensure output directory exists
-    outputDir := filepath.Dir(outputPath)
-    if outputDir != "" {
-        if err := os.MkdirAll(outputDir, 0755); err != nil {
-            return fmt.Errorf("failed to create output directory: %w", err)
-        }
-    }
-
-    // Run bg-remover
-    cmd := exec.Command(binaryPath, "-i", inputPath, "-o", outputPath)
-    output, err := cmd.CombinedOutput()
-
-    if err != nil {
-        return fmt.Errorf("bg-remover failed: %w\nOutput: %s", err, output)
-    }
-
-    // Verify output file was created
-    if _, err := os.Stat(outputPath); os.IsNotExist(err) {
-        return fmt.Errorf("output file not created: %s", outputPath)
-    }
-
-    return nil
-}
-
-func main() {
-    err := RemoveBackground("photo.jpg", "photo_no_bg.png", "./bg-remover")
-    if err != nil {
-        fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-        os.Exit(1)
-    }
-    fmt.Println("Background removed successfully!")
+if output, err := cmd.CombinedOutput(); err != nil {
+    return fmt.Errorf("bg-remover failed: %w\n%s", err, output)
 }
 ```
 
-### 6. Docker Container Integration
+### GrabCut Mode
+
+```bash
+./bg-remover -i input.jpg -o output.png --grabcut -q quality -n 12 -e guided
+```
+
+GrabCut does not use a model, but official Linux binaries still need `libonnxruntime.so.1` to be present because it is a load-time dependency.
+
+## Docker Container Integration
+
+Use a glibc-based image such as Debian 12 or Ubuntu 22.04+. The official Linux binary does not need OpenCV packages installed.
 
 ```dockerfile
-FROM alpine:3.19
+FROM debian:12-slim
 
-# Copy the bg-remover binary into the container
-COPY bg-remover /usr/local/bin/bg-remover
+COPY bg-remover-ubuntu-x86_64 /usr/local/bin/bg-remover
+COPY libonnxruntime.so.1 /usr/local/bin/libonnxruntime.so.1
 RUN chmod +x /usr/local/bin/bg-remover
 
-# Install OpenCV runtime libraries (not dev packages)
-RUN apk add --no-cache opencv libstdc++
-
-# Set working directory
 WORKDIR /app
-
-# Default command
 ENTRYPOINT ["/usr/local/bin/bg-remover"]
-CMD ["-i", "input.jpg", "-o", "output.png"]
+CMD ["-i", "input.jpg", "-o", "output.png", "--model", "models/u2net.onnx"]
 ```
 
-Run with:
-```bash
-docker run -v $(pwd):/app your-image -i /app/input.jpg -o /app/output.png
-```
+## Laravel Cloud Deployment
 
-### 7. REST API Wrapper (Python Flask Example)
+Laravel Cloud workers are arm64 Graviton hosts in a managed runtime, not a user-provided container. Use the official Linux arm64 binary directly.
 
-```python
-from flask import Flask, request, send_file, jsonify
-import subprocess
-import os
-import uuid
-from werkzeug.utils import secure_filename
+Ship these files with your application:
 
-app = Flask(__name__)
-UPLOAD_FOLDER = '/tmp/bg-remover-uploads'
-os.makedirs(UPLOAD_FOLDER, exist_ok=True)
+- `bg-remover-linux-arm64`
+- `libonnxruntime.so.1` from `onnxruntime-linux-aarch64-1.19.2.tgz`, next to the binary or under `lib/`
+- Your ONNX model file, if using default ML mode
 
-@app.route('/remove-background', methods=['POST'])
-def remove_background_api():
-    """
-    API endpoint to remove background from uploaded image.
+Run `chmod +x bg-remover-linux-arm64` during deployment, then invoke the binary from your worker process with `--model <path>` or `--grabcut`.
 
-    POST /remove-background
-    Form data: image file
-    Returns: PNG file with transparent background
-    """
-    if 'image' not in request.files:
-        return jsonify({'error': 'No image provided'}), 400
+## Laravel Forge And Vapor Notes
 
-    file = request.files['image']
-    if file.filename == '':
-        return jsonify({'error': 'Empty filename'}), 400
-
-    # Generate unique filenames
-    file_id = str(uuid.uuid4())
-    input_path = os.path.join(UPLOAD_FOLDER, f"{file_id}_input")
-    output_path = os.path.join(UPLOAD_FOLDER, f"{file_id}_output.png")
-
-    try:
-        # Save uploaded file
-        file.save(input_path)
-
-        # Run bg-remover
-        result = subprocess.run(
-            ['./bg-remover', '-i', input_path, '-o', output_path],
-            capture_output=True,
-            text=True,
-            check=True
-        )
-
-        # Return the processed image
-        return send_file(output_path, mimetype='image/png')
-
-    except subprocess.CalledProcessError as e:
-        return jsonify({'error': 'Background removal failed', 'details': e.stderr}), 500
-    except Exception as e:
-        return jsonify({'error': str(e)}), 500
-    finally:
-        # Cleanup
-        if os.path.exists(input_path):
-            os.remove(input_path)
-        if os.path.exists(output_path):
-            os.remove(output_path)
-
-if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5000)
-```
-
-## Performance Considerations
-
-### Processing Time
-- Depends on image resolution and complexity
-- Typical processing: 1-5 seconds for standard photos (1-5 MP)
-- Larger images (10+ MP) may take 10-30 seconds
-
-### Resource Usage
-- **Memory**: Proportional to image size (~3-4x the input file size in RAM)
-- **CPU**: Single-threaded OpenCV processing
-- **Disk**: Output PNG files are typically larger than JPEG inputs due to alpha channel
-
-### Optimization Tips
-1. **Resize large images** before processing if high resolution isn't needed
-2. **Process in parallel** - bg-remover can handle multiple simultaneous executions
-3. **Use temp storage** for intermediate files to avoid cluttering the filesystem
-4. **Set timeouts** to handle edge cases where processing takes too long
+- Forge on Ubuntu 22.04+ can run `bg-remover-ubuntu-x86_64` directly with the x64 ONNX Runtime library co-located.
+- Vapor container images should use a glibc base if they use the official Linux binaries. Alpine/musl is not an official target in the current build pipeline.
+- Laravel Cloud should use the arm64 guidance above and does not require a custom container.
 
 ## Batch Processing Example
 
 ```bash
 #!/bin/bash
-# Process all images in a directory
 
 INPUT_DIR="./images"
 OUTPUT_DIR="./processed"
+MODEL_PATH="./models/u2net.onnx"
 
 mkdir -p "$OUTPUT_DIR"
 
@@ -382,41 +198,37 @@ for img in "$INPUT_DIR"/*.{jpg,jpeg,png}; do
     filename=$(basename "$img")
     name="${filename%.*}"
 
-    echo "Processing: $filename"
-    ./bg-remover -i "$img" -o "$OUTPUT_DIR/${name}_no_bg.png"
+    ./bg-remover -i "$img" -o "$OUTPUT_DIR/${name}_no_bg.png" --model "$MODEL_PATH"
 done
-
-echo "Batch processing complete!"
 ```
 
 ## Error Handling
 
-Common errors and solutions:
-
 | Error | Cause | Solution |
 |-------|-------|----------|
-| File not found | Invalid input path | Check file exists and path is correct |
+| `libonnxruntime.so.1` not found | Missing dynamic ONNX Runtime library | Place the arch-matching library next to the binary or in `./lib/` |
+| `GLIBC_2.34 not found` | Runtime glibc is too old | Use Debian 12, Ubuntu 22.04+, or another glibc >= 2.34 environment |
+| ML mode requires `--model` | Default ML mode needs an ONNX model | Pass `--model <path>` or use `--grabcut` |
+| File not found | Invalid input path | Check that the file exists and the path is correct |
 | Cannot write output | Permission denied or invalid output path | Verify write permissions and directory exists |
 | Invalid image format | Corrupted or unsupported file | Validate input is a valid image file |
-| Segmentation fault | Extremely large image or insufficient memory | Reduce image size or increase available RAM |
 
 ## Output Format
 
 - **Format**: PNG with alpha channel (RGBA)
 - **Bit depth**: 8-bit per channel
 - **Transparency**: Full alpha channel support (0-255)
-- **Compression**: PNG default compression
 
 ## Limitations
 
-1. **Single subject focus**: Works best with single subjects on contrasting backgrounds
-2. **Complex backgrounds**: May struggle with intricate details (hair, fur) against similar-colored backgrounds
-3. **Static algorithm**: Uses predefined GrabCut parameters (no runtime tuning)
-4. **No batch mode**: Must call binary separately for each image
+1. Default ML mode requires a compatible ONNX segmentation model.
+2. Official Linux binaries need `libonnxruntime.so.1` even for `--grabcut`.
+3. GrabCut works best with single subjects on contrasting backgrounds.
+4. The CLI does not include native batch mode; call it once per image.
 
 ## Support
 
-For issues or questions about this tool, contact the repository maintainer or open an issue on the project repository.
+Open binary package issues in [artisan-build/bg-remover](https://github.com/artisan-build/bg-remover).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,231 +1,205 @@
 # bg-remover
 
-A self-hosted background removal tool using OpenCV's GrabCut algorithm. This C++ implementation works without Python dependencies and supports Alpine, Ubuntu, and macOS platforms.
+A self-hosted C++ background removal CLI that outputs PNG files with an alpha channel. The official binaries support ML segmentation by default, with OpenCV GrabCut available as an opt-out mode.
 
 ## Overview
 
-bg-remover is a command-line tool that removes backgrounds from images, creating transparent PNG outputs. It's designed as a self-hosted alternative to remove.bg that runs entirely in your own environment.
+`bg-remover` is designed as a standalone binary package for applications that need background removal without Python dependencies. Official Linux builds statically bundle OpenCV, libstdc++, and libgcc; the only non-system runtime library you must provide is the platform-matching ONNX Runtime shared library.
 
-## Features
+## Supported Targets
 
-- Pure C++ implementation with OpenCV
-- No Python dependencies required
-- Multi-platform support:
-  - **Alpine Linux (x86_64)** - for Laravel Vapor
-  - **Ubuntu (x86_64)** - for Laravel Forge
-  - **macOS (Universal)** - ARM64 + x86_64 for development
-- GrabCut algorithm for accurate background segmentation
-- Outputs PNG with alpha channel transparency
-- Docker-based build system for reproducibility
+| Target | Binary | Runtime Notes |
+|--------|--------|---------------|
+| Linux x86_64 | `bg-remover-ubuntu-x86_64` | glibc >= 2.34; static OpenCV; requires `libonnxruntime.so.1` from ONNX Runtime linux-x64 1.19.2 |
+| Linux arm64 | `bg-remover-linux-arm64` | glibc >= 2.34; static OpenCV; requires `libonnxruntime.so.1` from ONNX Runtime linux-aarch64 1.19.2 |
+| macOS arm64 | `bg-remover-macos-arm64` | Development-only; dynamically links Homebrew OpenCV and ONNX Runtime |
+
+There is no official Windows build. Alpine/musl and universal macOS binaries are not produced by the current release workflow.
+
+## Runtime Contract
+
+- Linux binaries are built with static OpenCV, static libstdc++, and static libgcc.
+- Linux binaries dynamically load only `libonnxruntime.so.1` plus glibc system libraries.
+- The Linux runtime search path is `$ORIGIN:$ORIGIN/lib`, so `libonnxruntime.so.1` must be next to the binary or in a sibling `lib/` directory.
+- `libonnxruntime.so.1` is required at process load time, even when you pass `--grabcut`.
+- The Linux glibc floor is `GLIBC_2.34`, so deploy on Debian 12, Ubuntu 22.04+, or another glibc >= 2.34 runtime.
+- Official Linux binaries are tens of MB because OpenCV is statically linked. Static builds are intentionally larger than dynamically linked builds.
+- macOS binaries are not self-contained and are intended for development machines with `brew install opencv onnxruntime`.
 
 ## Quick Start
 
-### Installation
-
-**Option 1: Download Pre-built Binary**
-
-Download the appropriate binary for your platform from the [latest release](https://github.com/artisan-build/bg-remover/releases/latest):
-- `bg-remover-alpine-x86_64` - for Alpine Linux (Laravel Vapor)
-- `bg-remover-ubuntu-x86_64` - for Ubuntu (Laravel Forge)
-- `bg-remover-macos-universal` - for macOS (ARM64 + Intel)
+Download the binary for your platform from the [latest release](https://github.com/artisan-build/bg-remover/releases/latest). Then download the matching ONNX Runtime package from [microsoft/onnxruntime](https://github.com/microsoft/onnxruntime/releases/tag/v1.19.2) and place its shared library with the binary.
 
 ```bash
-# Make it executable
-chmod +x bg-remover-*
+# Linux x86_64 example
+wget https://github.com/artisan-build/bg-remover/releases/latest/download/bg-remover-ubuntu-x86_64
+mkdir -p lib
 
-# Run it
-./bg-remover-alpine-x86_64 -i input.jpg -o output.png
+# Extract libonnxruntime.so.1 from onnxruntime-linux-x64-1.19.2.tgz into ./lib/
+chmod +x bg-remover-ubuntu-x86_64
+
+# ML is the default and requires --model
+./bg-remover-ubuntu-x86_64 -i input.jpg -o output.png --model /path/to/u2net.onnx
+
+# GrabCut is the opt-out mode and does not use a model
+./bg-remover-ubuntu-x86_64 -i input.jpg -o output.png --grabcut
 ```
 
-**Option 2: Build from Source**
-
-```bash
-# Clone repository
-git clone https://github.com/artisan-build/bg-remover.git
-cd bg-remover
-
-# Build for your platform
-make alpine    # Alpine Linux via Docker
-make ubuntu    # Ubuntu via Docker
-make           # Local build (requires OpenCV installed)
-```
-
-### Basic Usage
-
-```bash
-./bg-remover -i input.jpg -o output.png
-```
-
-That's it! Input goes in, transparent background PNG comes out.
-
-### Command-Line Options
+## Command-Line Interface
 
 | Option | Description | Example |
 |--------|-------------|---------|
-| `-i, --input` | Input image path | `-i photo.jpg` |
-| `-o, --output` | Output PNG path | `-o result.png` |
+| `-i, --input` | Input image path, or `-` for stdin | `-i photo.jpg` |
+| `-o, --output` | Output PNG path, or `-` for stdout | `-o result.png` |
+| `-q, --quality` | GrabCut quality preset: `fast`, `balanced`, `quality` | `-q quality` |
+| `-n, --iterations` | GrabCut iterations, 1-20 | `-n 12` |
+| `-m, --margin` | GrabCut edge margin/inset in pixels | `-m 20` |
+| `-e, --edge-mode` | GrabCut edge refinement: `blur`, `bilateral`, `guided` | `-e guided` |
+| `--model` | ONNX model path for default ML mode | `--model u2net.onnx` |
+| `--grabcut` | Use OpenCV GrabCut instead of ML | `--grabcut` |
+| `--ml` | No-op for official binaries because ML is already default | `--ml` |
 | `-h, --help` | Show help message | `-h` |
+
+The output is always a PNG with an alpha channel.
 
 ## Integration
 
-### Quick Examples
+### Python
 
-**Python**
 ```python
 import subprocess
-subprocess.run(["./bg-remover", "-i", "input.jpg", "-o", "output.png"], check=True)
+
+subprocess.run([
+    "./bg-remover-ubuntu-x86_64",
+    "-i", "input.jpg",
+    "-o", "output.png",
+    "--model", "/path/to/u2net.onnx",
+], check=True)
 ```
 
-**Node.js**
+### Node.js
+
 ```javascript
-const { execSync } = require('child_process');
-execSync('./bg-remover -i input.jpg -o output.png');
+const { execFileSync } = require('child_process');
+
+execFileSync('./bg-remover-ubuntu-x86_64', [
+  '-i', 'input.jpg',
+  '-o', 'output.png',
+  '--grabcut',
+]);
 ```
 
-**PHP (Laravel)**
+### PHP / Laravel
+
 ```php
 use Illuminate\Support\Facades\Process;
 
-Process::run(['./bg-remover', '-i', 'input.jpg', '-o', 'output.png'])->throw();
-```
-
-**Go**
-```go
-cmd := exec.Command("./bg-remover", "-i", "input.jpg", "-o", "output.png")
-err := cmd.Run()
+Process::run([
+    './bg-remover-linux-arm64',
+    '-i', 'input.jpg',
+    '-o', 'output.png',
+    '--model', base_path('models/u2net.onnx'),
+])->throw();
 ```
 
 ### Laravel Package
 
-For Laravel applications, use the official package:
+This repository is the canonical binary package: [artisan-build/bg-remover](https://github.com/artisan-build/bg-remover).
 
-```bash
-composer require artisan-build/background-removal
-```
+TODO: The canonical Laravel wrapper package name needs confirmation. Existing historical references used multiple names, so this README intentionally avoids naming a wrapper package until it is verified.
 
-See [artisan-build/background-removal](https://github.com/artisan-build/background-removal) for full Laravel integration documentation.
+See [INTEGRATION.md](INTEGRATION.md) for deployment and process-wrapper examples.
 
-### Full Integration Guide
+## Laravel Cloud
 
-See [INTEGRATION.md](INTEGRATION.md) for:
-- Complete examples in Python, Node.js, PHP, Go, and more
-- REST API wrapper patterns
-- Error handling strategies
-- Batch processing examples
-- Performance optimization tips
+Laravel Cloud workers run on arm64 Graviton hosts in a managed runtime, not inside a user-provided container. Use the self-contained Linux arm64 binary directly:
+
+1. Ship `bg-remover-linux-arm64` with your application.
+2. Ship ONNX Runtime 1.19.2 `libonnxruntime.so.1` from `onnxruntime-linux-aarch64-1.19.2.tgz` next to the binary or under `lib/`.
+3. Mark the binary executable during deployment.
+4. Run with `--model <path>` for ML mode, or `--grabcut` to opt out to GrabCut.
+
+This is distinct from Forge/Vapor guidance: Laravel Cloud does not require you to build or run a container to use the binary.
 
 ## Building
 
-### Officially Supported Platforms
+The release workflow builds the three official targets as follows:
 
-| Platform | Use Case | Build Command |
-|----------|----------|---------------|
-| Alpine Linux | Laravel Vapor | `make alpine` |
-| Ubuntu | Laravel Forge | `make ubuntu` |
-| macOS | Development | `make` (requires OpenCV via Homebrew) |
+| Target | Build Path | Linkage |
+|--------|------------|---------|
+| Linux x86_64 | `Dockerfile.ubuntu` on Debian 12 | OpenCV/libstdc++/libgcc static; ONNX Runtime dynamic |
+| Linux arm64 | `Dockerfile.ubuntu-arm64` on Debian 12 arm64 | OpenCV/libstdc++/libgcc static; ONNX Runtime dynamic |
+| macOS arm64 | Native GitHub Actions runner with Homebrew | OpenCV and ONNX Runtime dynamic |
 
-### Build Requirements
+The Dockerfiles build OpenCV 4.10.0 from source as static libraries and link with ONNX Runtime 1.19.2. They copy `libonnxruntime.so.1` into `/app/lib` for verification, but release consumers should fetch the architecture-matching ONNX Runtime package themselves.
 
-**For Docker builds (Alpine/Ubuntu):**
-- Docker installed
-- No other dependencies needed
-
-**For local macOS build:**
-```bash
-brew install opencv
-make
-```
-
-### Build Options
+Local build commands:
 
 ```bash
-# Build for specific target
-make TARGET=alpine      # Alpine Linux
-make TARGET=ubuntu      # Ubuntu
-make TARGET=local       # Local system
+make ubuntu       # Docker x86_64 Linux build
+make linux-arm64  # Docker arm64 Linux build
 
-# Build with static linking (if supported)
-make TARGET=alpine LINK_MODE=static
-
-# Clean build artifacts
-make clean
+# macOS development build
+brew install opencv onnxruntime pkg-config
+make ML=1 TARGET=local OUTPUT=bg-remover-macos-arm64 CXXFLAGS="-std=c++17 -O3 -Wall"
 ```
+
+The historical `TARGET=alpine` and `Dockerfile.alpine` paths are not part of the current build pipeline.
 
 ## Community-Maintained Platform Builds
 
-Need bg-remover on Windows, ARM Linux, or another platform we don't officially support?
-
-See [FORKING.md](FORKING.md) for a complete guide on creating and maintaining your own platform builds. We maintain builds only for platforms we actively use (Alpine, Ubuntu, macOS), but the community is welcome to fork for additional platforms.
-
-### How It Works
-
-1. Fork this repository
-2. Create a Dockerfile for your platform
-3. Test and release binaries
-4. Submit a PR to add your fork to the list below
-
-### Community Forks
-
-_No community forks yet. Be the first! See [FORKING.md](FORKING.md) to get started._
-
-<!-- 
-When adding forks, use this format:
-
-| Platform | Maintainer | Repository | Status |
-|----------|------------|------------|--------|
-| Windows (x86_64) | [@username](https://github.com/username) | [username/bg-remover](https://github.com/username/bg-remover) | Active |
--->
+Need bg-remover on Windows, Alpine/musl, Linux ARM32, RISC-V, BSD, or another unsupported target? See [FORKING.md](FORKING.md) for guidance on maintaining a fork.
 
 ## Technical Details
 
-- **Algorithm**: OpenCV GrabCut for foreground/background segmentation
-- **Processing**: Morphological operations (CLOSE, OPEN) for mask refinement
-- **Edge Smoothing**: Gaussian blur for natural alpha channel transitions
-- **Output Format**: PNG with RGBA (8-bit per channel)
+- **Default mode**: ML segmentation with an ONNX model supplied by `--model`.
+- **GrabCut mode**: OpenCV GrabCut via `--grabcut`; supports quality, iteration, margin, and edge-mode flags.
+- **Output format**: PNG with RGBA, 8-bit per channel.
+- **Model runtime**: ONNX Runtime 1.19.2.
 
 ## Performance
 
-- **Processing Time**: 1-5 seconds for typical photos (1-5 MP)
-- **Memory Usage**: ~3-4x input file size in RAM
-- **Best Results**: Single subjects on contrasting backgrounds
+- **Processing time**: Depends on model, image resolution, and GrabCut settings.
+- **Memory usage**: Typically several times the input image size plus model/runtime memory.
+- **Binary size**: Linux release binaries are tens of MB because OpenCV is statically linked.
 
 ## Troubleshooting
 
-**Problem**: `bg-remover: command not found`
-- **Solution**: Use `./bg-remover` or add to PATH
+**Problem**: `error while loading shared libraries: libonnxruntime.so.1`
 
-**Problem**: Output file not created
-- **Solution**: Ensure output directory exists and you have write permissions
+**Solution**: Place the architecture-matching `libonnxruntime.so.1` next to the binary or in `./lib/`. This is required even for `--grabcut` because the official Linux binaries link ONNX Runtime at load time.
 
-**Problem**: Poor background removal quality
-- **Solution**: Works best with clear subject-background contrast. Try images with simpler backgrounds.
+**Problem**: `GLIBC_2.34 not found`
 
-## Dependencies
+**Solution**: Run on Debian 12, Ubuntu 22.04+, or another glibc >= 2.34 environment.
 
-This software uses the following open source packages:
+**Problem**: Default invocation fails with `ML mode (default) requires --model <path>`
 
-- [OpenCV](https://opencv.org/) - Apache 2.0 License
-  - Used for image processing and background removal algorithms
-  - Must be installed separately (see Requirements section)
-  - License: https://opencv.org/license/
+**Solution**: Supply `--model /path/to/model.onnx`, or pass `--grabcut` to use the non-ML path.
 
-## License
+**Problem**: Poor GrabCut output quality
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+**Solution**: Try `-q quality`, increase `-n`, or use ML mode with a suitable segmentation model.
 
-OpenCV is licensed under the Apache 2.0 License, which is compatible with the MIT License used for this project.
+## Dependencies And Licenses
+
+- [OpenCV](https://opencv.org/) - Apache 2.0 License; statically linked into official Linux binaries and dynamically linked on macOS.
+- [ONNX Runtime](https://onnxruntime.ai/) - MIT License; `libonnxruntime.so.1` is dynamically loaded on Linux and must match the target architecture.
+
+This project is licensed under the MIT License. See [LICENSE](LICENSE).
 
 ## Repository Structure
 
 - `src/` - C++ source code
-- `Dockerfile.alpine` - Alpine Linux build configuration
-- `Dockerfile.ubuntu` - Ubuntu build configuration
-- `Makefile` - Build system with multi-platform support
-- `INTEGRATION.md` - Comprehensive integration guide
+- `Dockerfile.ubuntu` - Linux x86_64 static-OpenCV build
+- `Dockerfile.ubuntu-arm64` - Linux arm64 static-OpenCV build
+- `Makefile` - Local and Docker build helpers
+- `.github/workflows/build.yml` - Official release build matrix
+- `INTEGRATION.md` - Integration and deployment guide
 - `FORKING.md` - Guide for community platform support
 
 ## Contributing
 
-- Binary issues/features: Open in this repository
-- Laravel package issues: Open in [artisan-build/scalpels.app](https://github.com/artisan-build/scalpels.app)
-- Community platform builds: See [FORKING.md](FORKING.md)
+- Binary issues/features: Open in this repository.
+- Laravel wrapper issues: TODO pending canonical wrapper package confirmation.
+- Community platform builds: See [FORKING.md](FORKING.md).


### PR DESCRIPTION
## Summary
- Correct README, integration, forking, and release-note docs to match the current three-target build matrix and ML-default CLI behavior.
- Document Linux static OpenCV linkage, the co-located architecture-specific ONNX Runtime requirement, glibc >= 2.34, macOS dev-only dynamic linkage, and Laravel Cloud arm64 deployment.
- Stop publishing an ambiguous single `libonnxruntime.so.1` release asset and bump GitHub actions to current majors.

## Validation
- `git diff --check`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "OK #{f}" }' .github/workflows/build.yml .github/workflows/claude.yml .github/workflows/claude-code-review.yml`